### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/vault/Dockerfile
+++ b/vault/Dockerfile
@@ -1,1 +1,1 @@
-FROM vault:1.11.6
+FROM vault:1.12.2


### PR DESCRIPTION
`vault` changed recently. This pull request ensures you're using the latest version of the image and changes `vault` to the latest tag: `1.12.2`

New base image: `vault:1.12.2`